### PR TITLE
justify-items will center each pokemoncard in their cell

### DIFF
--- a/frontend/src/components/pokedex/Pokedex.module.css
+++ b/frontend/src/components/pokedex/Pokedex.module.css
@@ -1,6 +1,7 @@
 .grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
+    justify-items: center;
 }
 
 .pokemonDisplay {


### PR DESCRIPTION
A quick tweak. **No linked issues.**

# Before

![image](https://user-images.githubusercontent.com/68324342/116640539-f0935580-a9be-11eb-8ea8-6fd79de311d4.png)

# After

![image](https://user-images.githubusercontent.com/68324342/116640573-043ebc00-a9bf-11eb-8172-d857c239e3f8.png)

