### PR TITLE
[Bug] Fixing onClick crash with PokeType

### DIFF
--- a/frontend/src/components/global/PokeType.jsx
+++ b/frontend/src/components/global/PokeType.jsx
@@ -8,7 +8,7 @@ import { getGradientTypeColor } from "../../util/types";
  * @param onClick: An optional argument function that is run on click
  * @param size: An optional string argument for either "small" or "medium" component sizes
  */
-export default function PokeType({ typeName, onClick, size = "medium" }) {
+export default function PokeType({ typeName, onClick = () => {}, size = "medium" }) {
     // Type names are stylized to use a max of 6 letters
     const shortenedTypeName = {
         electric: "electr",


### PR DESCRIPTION
Closes #51 

Before, clicking on a `PokeType` without an onClick would cause the app to crash. Now, the onClick just does nothing by default, so you can click on a `PokeType` and nothing will happen.