### PR TITLE
[Bug] Ignoring case when searching for Pokemon

### DIFF
--- a/frontend/src/components/global/SearchBar.jsx
+++ b/frontend/src/components/global/SearchBar.jsx
@@ -9,7 +9,7 @@ export default function SearchBar({ onSearch }) {
                 className={styles.searchBar}
                 type="text"
                 placeholder="Search for a pokemon's name"
-                onKeyUp={(e) => onSearch(e.target.value)}
+                onKeyUp={(e) => onSearch(e.target.value.toLowerCase())}
             />
             <SearchIcon className={styles.searchIcon} />
         </div>


### PR DESCRIPTION
Closes #48 

The SearchBar component now converts the user's input to lower case before calling its `onSearch` function. Users can now search with uppercase characters.