### PR TITLE
[Bug] Register user error handling

### DIFF
--- a/backend/src/routes/api/users.js
+++ b/backend/src/routes/api/users.js
@@ -18,6 +18,11 @@ process.on("unhandledRejection", (reason, promise) => {
 
 // Create new user
 router.post("/register", async (req, res) => {
+    if (!req.body.username || !req.body.password) {
+        res.status(HTTP_BAD_REQUEST).send("Empty username and/or password");
+        return;
+    }
+
     await createUser(
         {
             username: req.body.username,

--- a/backend/src/users/user-dao.js
+++ b/backend/src/users/user-dao.js
@@ -12,7 +12,10 @@ async function createUser(user, callback) {
     // Create password hash using bcrypt, with salt
     bcrypt.genSalt(10, (err, salt) => {
         bcrypt.hash(user.password, salt, (err, hash) => {
-            if (err) callback(null, err);
+            if (err) {
+                callback(null, err);
+                return;
+            }
             dbUser.password = hash;
 
             // After hashing password, save user and return them


### PR DESCRIPTION
Closes #66 

Fixed some bad code that I wrote for the functions in `user-dao.js`. Two changes
- Fixed the broken switch statement for the `/users/register` POST endpoint
- Fixed the `getJwtForUser` function attempting to read info from the user object even after the user is not found.

This has gotten rid of any promise rejection warnings that I could find. If there are any that still persist let me know so I can fix before merging.