### PR TITLE
Using an array instead of a Set for the User's upvotedTeams

### DIFF
--- a/backend/src/routes/api/users.js
+++ b/backend/src/routes/api/users.js
@@ -28,7 +28,7 @@ router.post("/register", async (req, res) => {
             username: req.body.username,
             password: req.body.password,
             comments: [],
-            upvotedTeams: new Set(),
+            upvotedTeams: [],
         },
         (newUser, error) => {
             if (error) {


### PR DESCRIPTION
- There was a bug in the backend where creating a new user resulted in a teamID being added to the user's set of upvotedTeams, even though the user had just been created and had not upvoted any teams.
- To resolve this bug, the User's upvotedTeams is initialised to an empty array rather than a new Set. 

-----------------
Closes #70 